### PR TITLE
Remove stapler generated files from source

### DIFF
--- a/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/CascadingChoiceParameterDefinition.stapler
+++ b/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/CascadingChoiceParameterDefinition.stapler
@@ -1,2 +1,0 @@
-#Friday July 28 02:39:00 EDT 2013
-constructor=name,parentPropertyName,script,description,uuid,remote,readonlyInputField,classPath

--- a/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/ChoiceParameterDefinition.stapler
+++ b/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/ChoiceParameterDefinition.stapler
@@ -1,2 +1,0 @@
-#Sun Sep 19 00:45:21 PDT 2010
-constructor=name,script,description,uuid,remote,readonlyInputField,classPath

--- a/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/StringParameterDefinition.stapler
+++ b/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/StringParameterDefinition.stapler
@@ -1,2 +1,0 @@
-#Sun Sep 19 00:45:21 PDT 2010
-constructor=name,script,description,remote,readonlyInputField,classPath

--- a/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/scriptler/ScriptlerChoiceParameterDefinition.stapler
+++ b/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/scriptler/ScriptlerChoiceParameterDefinition.stapler
@@ -1,1 +1,0 @@
-constructor=name,description,uuid,scriptlerScriptId,parameters,remote,readonlyInputField

--- a/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/scriptler/ScriptlerStringParameterDefinition.stapler
+++ b/src/main/java/com/seitenbau/jenkins/plugins/dynamicparameter/scriptler/ScriptlerStringParameterDefinition.stapler
@@ -1,1 +1,0 @@
-constructor=name,description,uuid,scriptlerScriptId,parameters,remote,readonlyInputField


### PR DESCRIPTION
As far as I know, these files are automatically generated by Stapler. No reason (and probably not a good idea) to keep them with the source code.

This PR simply removes the *.stapler files from the source.